### PR TITLE
 Setup docker compose for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM elixir:1.14.3-alpine
+
+WORKDIR /app
+
+RUN mix local.hex --force && mix local.rebar --force
+
+COPY . ./
+
+RUN mix deps.get && mix deps.compile
+
+EXPOSE 4000
+
+CMD ["mix", "phx.server"]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,61 @@
 # UScore
 
-To start your Phoenix server:
+UScore is a User Scoring API that keeps track of user points over time.
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.setup`
-  * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+## Requirements
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+* [Docker]
 
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+## Setup
 
-## Learn more
+_This setup covers installation using [Docker]. Make sure you have it up and running before continuing._
 
-  * Official website: https://www.phoenixframework.org/
-  * Guides: https://hexdocs.pm/phoenix/overview.html
-  * Docs: https://hexdocs.pm/phoenix
-  * Forum: https://elixirforum.com/c/phoenix-forum
-  * Source: https://github.com/phoenixframework/phoenix
+Clone the repository into your local machine:
+
+```sh
+$ git clone git@github.com:davidbrusius/uscore.git
+```
+
+Switch to the project directory:
+
+```sh
+cd uscore
+```
+
+Build docker images:
+
+```sh
+docker-compose build
+```
+
+Setup UScore database:
+
+```sh
+docker-compose run uscore mix ecto.setup
+```
+
+All done! You can now run the UScore API!
+
+## Running
+
+Run the UScore API:
+
+```sh
+$ docker-compose up -d
+```
+
+Watch application logs:
+
+```sh
+$ docker-compose logs -f
+```
+
+The API will be available at http://localhost:4000
+
+Shutdown the UScore API:
+
+```sh
+$ docker-compose down
+```
+
+[docker]: (https://www.docker.com/)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,7 +4,7 @@ import Config
 config :uscore, UScore.Repo,
   username: "postgres",
   password: "postgres",
-  hostname: "localhost",
+  hostname: "db",
   database: "uscore_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
@@ -19,7 +19,7 @@ config :uscore, UScore.Repo,
 config :uscore, UScoreWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  uscore:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 4000:4000
+    environment:
+      MIX_ENV: dev
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+  db:
+    image: postgres:15.1-alpine
+    ports:
+      - 5432:5432
+    volumes:
+      - data:/var/lib/postgresql/data
+volumes:
+  data:


### PR DESCRIPTION
## Description

[Docker compose](https://docs.docker.com/compose/) speeds up and simplifies local development setup. We are using it to run our UScore API along with a postgres database.

The README file was also updated to provide instructions for setting up and running the app using docker compose.