### PR TITLE
Add users table and seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 UScore is a User Scoring API that keeps track of user points over time.
 
+**GitHub Pull Requests contain valuable information about decisions made during the
+coding process. Please refer to them for more details.**
+
 ## Requirements
 
 * [Docker]

--- a/priv/repo/migrations/20230202150839_add_users_table.exs
+++ b/priv/repo/migrations/20230202150839_add_users_table.exs
@@ -1,0 +1,11 @@
+defmodule UScore.Repo.Migrations.AddUsersTable do
+  use Ecto.Migration
+
+  def change do
+    create table("users") do
+      add :points, :integer, default: 0
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,11 +1,10 @@
-# Script for populating the database. You can run it as:
-#
-#     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     UScore.Repo.insert!(%UScore.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+alias UScore.Repo
+
+# Generate 1,000,000 user seeds with 0 points (default value for this column)
+Repo.query!("TRUNCATE TABLE users;")
+
+Repo.query!("""
+INSERT INTO users (inserted_at, updated_at) (
+  SELECT date_now, date_now FROM generate_series(1, 1000000), NOW() as date_now
+);
+""")


### PR DESCRIPTION
## Description

* Add a new users table containing their id, points and record timestamps.

* Add 1 million users as seed data: 
For seeding the data, I found out using a custom built SQL query to be the most efficient approach. Although, we could also build some concurrent Elixir code which spins up many processes concurrently (based on db pool size).

  Here is a sample of the Elixir approach I came up with:

```elixir
postgres_max_params = 65_535
params = [:inserted_at, :updated_at]
batch_size = div(postgres_max_params, length(params))

date_now =
  DateTime.utc_now()
  |> DateTime.to_naive()
  |> NaiveDateTime.truncate(:second)

1..1_000_000
|> Stream.map(fn _ -> %{inserted_at: date_now, updated_at: date_now} end)
|> Stream.chunk_every(batch_size)
|> Task.async_stream(
  fn users ->
    Repo.insert_all(User, users)
  end,
  ordered: false,
  # same as db pool size set in config/test.exs
  max_concurrency: 10
)
|> Enum.to_list()
```

  As we can see, we are limited by the Postgres Max Params, which varies based on the number of attributes we send in the insert call. Tweaking the pool size does not help much as we start hitting db connection timeouts given queries are heavy and take some time to execute.

  Using the raw SQL approach with `generate_series` forwards the responsibility of bulk inserting to the database which is optimized for such scenarios. Other benefits is that it entails less resource usage (db connections, memory and cpu).