### PR TITLE
Add db constraint to ensure points are within the required range

### DIFF
--- a/priv/repo/migrations/20230205202753_ensure_points_within_range.exs
+++ b/priv/repo/migrations/20230205202753_ensure_points_within_range.exs
@@ -1,0 +1,9 @@
+defmodule UScore.Repo.Migrations.EnsurePointsWithinRange do
+  use Ecto.Migration
+
+  def change do
+    create constraint("users", :points_must_be_within_range,
+             check: "points >= 0 AND points <= 100"
+           )
+  end
+end

--- a/test/uscore/users_test.exs
+++ b/test/uscore/users_test.exs
@@ -72,20 +72,23 @@ defmodule UScore.UsersTest do
   describe "regenerate_points/0" do
     test "regenerates all users points randomly" do
       date_now = ClockMock.utc_now() |> date_to_db_format()
-      user = %{points: -1, inserted_at: date_now, updated_at: date_now}
+      user = %{points: 0, inserted_at: date_now, updated_at: date_now}
       Repo.insert_all(User, [user, user, user])
+      Repo.query!("SELECT setseed(1);")
 
       Users.regenerate_points()
 
-      for user <- Repo.all(User) do
-        assert user.points in 0..100
-      end
+      [user1, user2, user3] = Repo.all(User)
+
+      assert 40 == user1.points
+      assert 75 == user2.points
+      assert 39 == user3.points
     end
 
     test "updates users timestamps" do
       yesterday = ClockMock.utc_now() |> DateTime.add(-1, :day) |> date_to_db_format()
 
-      user = %{points: -1, inserted_at: yesterday, updated_at: yesterday}
+      user = %{points: 0, inserted_at: yesterday, updated_at: yesterday}
       Repo.insert_all(User, [user, user, user])
 
       Users.regenerate_points()


### PR DESCRIPTION
## Description

As, for performance reasons, we decided not to use Ecto changesets and validations to regenerate the users points, we need to ensure the correct parameters are being sent to the db `random()` function call in `UScore.Users.regenerate_points/0`. A db constraint comes in handy in such cases and will help us track any drifts while also preventing users with points outside the 0..100 range.